### PR TITLE
fix(npm): support for npm ^9

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://jan-molak.github.io/tiny-types/",
   "engines": {
     "node": "^14 || ^16 || ^18",
-    "npm": "^6 || ^7 || ^8 || ^9.0.0"
+    "npm": "^6 || ^7 || ^8 || ^9"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",


### PR DESCRIPTION
Warning about unsuppoorted npm version.

When I try to install the package in my project I receive a warning about unsupported npm version. In history I found that version 9.0.0 was set by the dependency bot, so I change it to ^9.


$ node --version
v18.14.2
& npm --version
9.6.0
$ npm i tiny-types
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'tiny-types@1.19.0',
npm WARN EBADENGINE   required: { node: '^14 || ^16 || ^18', npm: '^6 || ^7 || ^8' },
npm WARN EBADENGINE   current: { node: 'v18.14.2', npm: '9.6.0' }
npm WARN EBADENGINE }

added 1 package, and audited 2 packages in 1s

found 0 vulnerabilities
```